### PR TITLE
Add Python helper tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,8 @@ vibeconfig.local.json
 # Generated documentation
 /docs/html/
 /docs/latex/
+
+# Poetry virtual environment and build artifacts
+/python/.venv/
+/python/dist/
+/python/*.egg-info/

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,3 +46,24 @@ locate `libvibelang`. You can set `LD_LIBRARY_PATH` (or `DYLD_LIBRARY_PATH`
        -Wl,-rpath,/usr/local/lib
    ```
    The program will print a short joke about the given topic.
+
+## Using the Python helpers
+
+The `python` directory contains a small helper package that can compile and load
+`.vibe` files directly from Python. The two main functions are
+`vibelang.compile()` and `vibelang.load()`.
+
+```python
+from vibelang import compile, load
+
+# Compile a VibeLang file using vibec
+so_file = compile("joke.vibe")
+
+# Load the shared library and call the generated function
+module = load("joke.vibe")
+print(module.tellJoke(b"computers"))
+```
+
+`load()` ensures the runtime library `libvibelang` is available. If it is not in
+a system search path, set `VIBELANG_LIB_DIR` (or `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH`)
+to the directory containing the library.

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,32 @@
+# VibeLang Python SDK
+
+This package contains helper utilities for compiling and loading VibeLang modules directly from Python. It is managed with [Poetry](https://python-poetry.org/).
+
+## Installation
+
+From this directory run:
+
+```bash
+poetry install
+```
+
+This installs the package in a virtual environment created under `.venv`. You may also install it with `pip` directly:
+
+```bash
+pip install -e .
+```
+
+## Usage
+
+```python
+from vibelang import compile, load
+
+# Build a VibeLang source file using vibec
+so_file = compile("joke.vibe")
+
+# Load the module and call a generated function
+module = load(so_file)
+print(module.tellJoke(b"computers"))
+```
+
+Ensure the runtime library `libvibelang` can be located by setting `VIBELANG_LIB_DIR` or adjusting `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH` accordingly.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "vibelang"
+version = "0.1.0"
+description = "Python helpers for compiling and loading VibeLang modules"
+authors = ["VibeLang Contributors"]
+license = "MIT"
+readme = "README.md"
+packages = [{ include = "vibelang" }]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/python/vibelang/__init__.py
+++ b/python/vibelang/__init__.py
@@ -1,0 +1,5 @@
+"""Python helpers for compiling and loading VibeLang modules."""
+
+from .build import compile, load, VibeModule
+
+__all__ = ["compile", "load", "VibeModule"]

--- a/python/vibelang/build.py
+++ b/python/vibelang/build.py
@@ -1,0 +1,112 @@
+"""Utilities for compiling VibeLang sources and loading the resulting modules."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import shutil
+import subprocess
+import sys
+from ctypes import util
+from pathlib import Path
+
+
+class VibeModule:
+    """Simple wrapper around a loaded VibeLang module."""
+
+    def __init__(self, library: ctypes.CDLL, runtime: ctypes.CDLL) -> None:
+        self._lib = library
+        self._runtime = runtime
+
+    def __getattr__(self, name: str):
+        return getattr(self._lib, name)
+
+
+def compile(source: str | os.PathLike[str], vibec: str | None = None) -> Path:
+    """Compile a `.vibe` file using ``vibec`` and return the path to the ``.so``.
+
+    If ``vibec`` fails to create the shared library, this function will attempt
+    to build it directly using the system compiler.
+    """
+    vibec_bin = vibec or shutil.which("vibec")
+    if vibec_bin is None:
+        raise FileNotFoundError("vibec executable not found in PATH")
+
+    src = Path(source)
+
+    # Ensure the runtime library can be located by vibec
+    env = os.environ.copy()
+    lib_dir = env.get("VIBELANG_LIB_DIR")
+    if not lib_dir:
+        # Assume build layout: vibec is in <root>/build/bin
+        vibec_path = Path(vibec_bin).resolve()
+        lib_dir = str(vibec_path.parent.parent / "lib")
+    if os.path.isdir(lib_dir):
+        ld_var = "DYLD_LIBRARY_PATH" if sys.platform == "darwin" else "LD_LIBRARY_PATH"
+        env[ld_var] = lib_dir + os.pathsep + env.get(ld_var, "")
+
+    subprocess.run([vibec_bin, str(src)], check=True, env=env)
+
+    so_path = src.with_suffix(".so")
+    if not so_path.exists():
+        # Fallback: manually build the shared library
+        c_file = src.with_suffix(".c")
+        cc = shutil.which("cc") or shutil.which("gcc")
+        root = Path(__file__).resolve().parents[2]
+        include_dirs = [root / "include", root / "src", root / "src" / "utils"]
+        cmd = [cc, "-shared", "-fPIC", str(c_file)]
+        for inc in include_dirs:
+            cmd.extend(["-I", str(inc)])
+        # Link against static runtime components to avoid unresolved symbols
+        cmd.extend([
+            str(Path(lib_dir) / "libvibelang_runtime.a"),
+            str(Path(lib_dir) / "libvibelang_utils.a"),
+            str(Path(lib_dir) / "libcjson.a"),
+            "-lcurl",
+            "-o",
+            str(so_path),
+        ])
+        subprocess.run(cmd, check=True, env=env)
+    if not so_path.exists():
+        raise RuntimeError(f"Expected shared library {so_path} not produced")
+    return so_path
+
+
+def _load_runtime() -> ctypes.CDLL:
+    """Load ``libvibelang`` and initialize the runtime."""
+    libname = util.find_library("vibelang")
+    runtime = None
+    if libname:
+        runtime = ctypes.CDLL(libname, mode=ctypes.RTLD_GLOBAL)
+    else:
+        lib_dir = os.environ.get("VIBELANG_LIB_DIR")
+        if lib_dir:
+            for ext in ("so", "dylib"):
+                candidate = Path(lib_dir) / f"libvibelang.{ext}"
+                if candidate.exists():
+                    runtime = ctypes.CDLL(str(candidate), mode=ctypes.RTLD_GLOBAL)
+                    break
+    if runtime is None:
+        raise OSError(
+            "libvibelang not found. Install it or set VIBELANG_LIB_DIR/LD_LIBRARY_PATH"
+        )
+    if hasattr(runtime, "vibe_runtime_init"):
+        runtime.vibe_runtime_init.restype = ctypes.c_int
+        runtime.vibe_runtime_init.argtypes = []
+        runtime.vibe_runtime_init()
+    return runtime
+
+
+def load(path: str | os.PathLike[str], vibec: str | None = None) -> VibeModule:
+    """Compile (if needed) and load a VibeLang module.
+
+    ``path`` can point to either a ``.vibe`` source file or an already compiled
+    ``.so`` file. The returned object exposes the C functions via ``ctypes``.
+    """
+    file_path = Path(path)
+    if file_path.suffix == ".vibe" or not file_path.exists():
+        file_path = compile(file_path.with_suffix(".vibe"), vibec=vibec)
+
+    runtime = _load_runtime()
+    lib = ctypes.CDLL(str(file_path))
+    return VibeModule(lib, runtime)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,3 +75,9 @@ foreach(TEST_DATA_FILE ${TEST_DATA_FILES})
   get_filename_component(TEST_DATA_FILE_NAME ${TEST_DATA_FILE} NAME)
   configure_file(${TEST_DATA_FILE} ${CMAKE_BINARY_DIR}/tests/unit/data/${TEST_DATA_FILE_NAME} COPYONLY)
 endforeach()
+
+# Python helper tests
+add_test(
+    NAME python_helpers
+    COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/python/test_python_helpers.py
+)

--- a/tests/python/test_python_helpers.py
+++ b/tests/python/test_python_helpers.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from pathlib import Path
+
+# Add the project's Python package to the import path
+root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(root / "python"))
+
+from vibelang import compile, load
+
+
+def main():
+    vibec = root / "build" / "bin" / "vibec"
+    lib_dir = root / "build" / "lib"
+    os.environ["VIBELANG_LIB_DIR"] = str(lib_dir)
+
+    so_path = compile(root / "examples" / "joke.vibe", vibec=str(vibec))
+    assert so_path.exists(), "Shared library not produced"
+
+    module = load(so_path, vibec=str(vibec))
+    assert hasattr(module, "tellJoke"), "Expected symbol not found"
+    print("Python helpers test passed")
+
+    # Clean up generated files
+    c_file = so_path.with_suffix(".c")
+    if c_file.exists():
+        c_file.unlink()
+    if so_path.exists():
+        so_path.unlink()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- improve Python compile helper to build modules when vibec fails
- add a simple Python test and wire it up in CTest

## Testing
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6842cd23d48c8332a9bce26fd9de1ccb